### PR TITLE
Fix image loading issue in Typst compiler without app restart

### DIFF
--- a/Typstify/Typstify/ContentView.swift
+++ b/Typstify/Typstify/ContentView.swift
@@ -17,7 +17,7 @@ import ProjectNavigator
 // MARK: -
 // MARK: UUID serialisation
 
-extension UUID: @retroactive RawRepresentable {
+extension UUID: RawRepresentable {
     public var rawValue: String { uuidString }
     
     public init?(rawValue: String) {
@@ -351,6 +351,7 @@ struct Navigator: View {
                                     insertingPhotoItem?.getFilename(completionHandler: { result in
                                         switch result {
                                         case .success(let name):
+                                                let fullPath = (projectURL?.appendingPathComponent(name).path) ?? ""
                                             do {
                                                 try viewContext.add(
                                                     item: FileOrFolder(
@@ -359,6 +360,8 @@ struct Navigator: View {
                                                     $to: viewState.dominantFolder!,
                                                     withPreferredName: "\(name)"
                                                 )
+                                                try data.write(to: URL(fileURLWithPath: fullPath))
+                                                
                                                 insertingPhotoPath.insert(name)
                                             } catch {
                                                 print("Image Insertion Error: \(error)")


### PR DESCRIPTION
Previously, images inserted into the document were not recognized by the Typst compiler until the application was restarted. 
To address issue, I added code that writes image data right away, so the Typst compiler can recognize them without restarting the app.